### PR TITLE
Moves the factory into test support so ex_machina isnt needed in prod

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ def deps do
     %{:open_trip_planner_client,
       [
         github: "thecristen/open_trip_planner_client",
-        ref: "v0.9.0"
+        ref: "v0.9.3"
       ]}
   ]
 end
@@ -56,6 +56,19 @@ config :open_trip_planner_client,
   otp_url: "http://localhost:8080",
   timezone: "America/New_York"
 ```
+
+### Optional requirements
+
+We include a factory (`OpenTripPlannerClient.Test.Support.Factory`) to help with testing your usage of OpenTripPlanner.
+In order to use it, you'll also need to include the deps [ex_machina](https://hexdocs.pm/ex_machina/readme.html) and [faker](https://hexdocs.pm/faker/readme.html).
+
+```
+{:ex_machina, "2.8.0", only: [:dev, :test]},
+{:faker, "0.18.0", only: [:dev, :test]},
+```
+
+If you don't want or need the test helper and don't want or need ExMachina or Faker, no need to do anything.
+The library simply won't export the helper.
 
 ## Usage
 

--- a/mix.exs
+++ b/mix.exs
@@ -8,6 +8,7 @@ defmodule OpenTripPlannerClient.MixProject do
       app: :open_trip_planner_client,
       version: @version,
       elixir: "~> 1.16",
+      elixirc_paths: elixirc_paths(Mix.env()),
       deps: deps(),
       dialyzer: [plt_add_apps: [:mix]],
       aliases: [
@@ -54,4 +55,8 @@ defmodule OpenTripPlannerClient.MixProject do
       {:timex, "~> 3.0"}
     ]
   end
+
+  defp elixirc_paths(:dev), do: ["lib", "test/support"]
+  defp elixirc_paths(:test), do: ["lib", "test/support"]
+  defp elixirc_paths(_), do: ["lib"]
 end

--- a/mix.exs
+++ b/mix.exs
@@ -1,14 +1,14 @@
 defmodule OpenTripPlannerClient.MixProject do
   use Mix.Project
 
-  @version "0.9.2"
+  @version "0.9.3"
 
   def project do
     [
       app: :open_trip_planner_client,
       version: @version,
       elixir: "~> 1.16",
-      elixirc_paths: elixirc_paths(Mix.env()),
+      elixirc_paths: ["lib", "test/support"],
       deps: deps(),
       dialyzer: [plt_add_apps: [:mix]],
       aliases: [
@@ -46,8 +46,8 @@ defmodule OpenTripPlannerClient.MixProject do
       {:credo, "~> 1.7", only: [:dev, :test]},
       {:dialyxir, "~> 1.4", only: [:dev, :test], runtime: false},
       {:ex_doc, "~> 0.34", only: :dev, runtime: false},
-      {:ex_machina, "~> 2.8", only: [:dev, :test]},
-      {:faker, "~> 0.18", only: [:dev, :test]},
+      {:ex_machina, "~> 2.8", optional: true},
+      {:faker, "~> 0.18", optional: true},
       {:jason, "~> 1.4"},
       {:jason_structs,
        git: "https://github.com/ygunayer/jason_structs.git", branch: "ygunayer-namespaced-structs"},
@@ -55,8 +55,4 @@ defmodule OpenTripPlannerClient.MixProject do
       {:timex, "~> 3.0"}
     ]
   end
-
-  defp elixirc_paths(:dev), do: ["lib", "test/support"]
-  defp elixirc_paths(:test), do: ["lib", "test/support"]
-  defp elixirc_paths(_), do: ["lib"]
 end

--- a/test/open_trip_planner_client/itinerary_tag/earliest_arrival_test.exs
+++ b/test/open_trip_planner_client/itinerary_tag/earliest_arrival_test.exs
@@ -1,6 +1,8 @@
 defmodule OpenTripPlannerClient.ItineraryTag.EarliestArrivalTest do
   use ExUnit.Case, async: true
-  import OpenTripPlannerClient.Test.Factory
+
+  import OpenTripPlannerClient.Test.Support.Factory
+
   alias OpenTripPlannerClient.ItineraryTag
 
   test "tags, sorts" do

--- a/test/open_trip_planner_client/itinerary_tag/least_walking_test.exs
+++ b/test/open_trip_planner_client/itinerary_tag/least_walking_test.exs
@@ -1,6 +1,8 @@
 defmodule OpenTripPlannerClient.ItineraryTag.LeastWalkingTest do
   use ExUnit.Case, async: true
-  import OpenTripPlannerClient.Test.Factory
+
+  import OpenTripPlannerClient.Test.Support.Factory
+
   alias OpenTripPlannerClient.ItineraryTag
 
   test "tags, sorts" do

--- a/test/open_trip_planner_client/itinerary_tag/most_direct_test.exs
+++ b/test/open_trip_planner_client/itinerary_tag/most_direct_test.exs
@@ -1,6 +1,8 @@
 defmodule OpenTripPlannerClient.ItineraryTag.MostDirectTest do
   use ExUnit.Case, async: true
-  import OpenTripPlannerClient.Test.Factory
+
+  import OpenTripPlannerClient.Test.Support.Factory
+
   alias OpenTripPlannerClient.ItineraryTag
 
   test "tags, sorts, breaks tie" do

--- a/test/open_trip_planner_client/itinerary_tag/shortest_trip_test.exs
+++ b/test/open_trip_planner_client/itinerary_tag/shortest_trip_test.exs
@@ -1,6 +1,8 @@
 defmodule OpenTripPlannerClient.ItineraryTag.ShortestTripTest do
   use ExUnit.Case, async: true
-  import OpenTripPlannerClient.Test.Factory
+
+  import OpenTripPlannerClient.Test.Support.Factory
+
   alias OpenTripPlannerClient.ItineraryTag
 
   test "tags, sorts" do

--- a/test/open_trip_planner_client/itinerary_tag_test.exs
+++ b/test/open_trip_planner_client/itinerary_tag_test.exs
@@ -1,6 +1,8 @@
 defmodule OpenTripPlannerClient.ItineraryTagTest do
   use ExUnit.Case, async: true
-  import OpenTripPlannerClient.Test.Factory
+
+  import OpenTripPlannerClient.Test.Support.Factory
+
   alias OpenTripPlannerClient.ItineraryTag
 
   defmodule BadTag do

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -1,230 +1,233 @@
-defmodule OpenTripPlannerClient.Test.Support.Factory do
-  @moduledoc """
-  Generate OpenTripPlannerClient.Schema structs
-  """
-  use ExMachina
+if Code.ensure_loaded?(ExMachina) and Code.ensure_loaded?(Faker) do
+  defmodule OpenTripPlannerClient.Test.Support.Factory do
+    @moduledoc """
+    Generate OpenTripPlannerClient.Schema structs
+    """
 
-  alias OpenTripPlannerClient.Schema.{
-    Agency,
-    Geometry,
-    Itinerary,
-    LegTime,
-    Leg,
-    Place,
-    Route,
-    Step,
-    Stop,
-    Trip
-  }
+    use ExMachina
 
-  def agency_factory do
-    %Agency{
-      name: Faker.Util.pick(["MBTA", "Massport", "Logan Express"])
+    alias OpenTripPlannerClient.Schema.{
+      Agency,
+      Geometry,
+      Itinerary,
+      LegTime,
+      Leg,
+      Place,
+      Route,
+      Step,
+      Stop,
+      Trip
     }
-  end
 
-  def geometry_factory do
-    %Geometry{
-      points: Faker.Lorem.characters(12),
-      length: nil
-    }
-  end
+    def agency_factory do
+      %Agency{
+        name: Faker.Util.pick(["MBTA", "Massport", "Logan Express"])
+      }
+    end
 
-  def itinerary_factory do
-    legs = Faker.random_between(1, 3) |> build_leg_sequence()
-    %Leg{start: %LegTime{scheduled_time: first_start}} = List.first(legs)
-    %Leg{end: %LegTime{scheduled_time: last_end}} = List.last(legs)
+    def geometry_factory do
+      %Geometry{
+        points: Faker.Lorem.characters(12),
+        length: nil
+      }
+    end
 
-    %Itinerary{
-      accessibility_score: Faker.Random.Elixir.random_uniform(),
-      duration: legs |> Enum.map(& &1.duration) |> Enum.sum(),
-      end: last_end,
-      legs: legs,
-      number_of_transfers: length(legs) - 1,
-      start: first_start,
-      walk_distance:
-        legs |> Enum.filter(&(&1.mode == :WALK)) |> Enum.map(& &1.distance) |> Enum.sum()
-    }
-  end
+    def itinerary_factory do
+      legs = Faker.random_between(1, 3) |> build_leg_sequence()
+      %Leg{start: %LegTime{scheduled_time: first_start}} = List.first(legs)
+      %Leg{end: %LegTime{scheduled_time: last_end}} = List.last(legs)
 
-  def leg_time_factory do
-    %LegTime{
-      scheduled_time: Faker.DateTime.forward(2),
-      estimated: nil
-    }
-  end
+      %Itinerary{
+        accessibility_score: Faker.Random.Elixir.random_uniform(),
+        duration: legs |> Enum.map(& &1.duration) |> Enum.sum(),
+        end: last_end,
+        legs: legs,
+        number_of_transfers: length(legs) - 1,
+        start: first_start,
+        walk_distance:
+          legs |> Enum.filter(&(&1.mode == :WALK)) |> Enum.map(& &1.distance) |> Enum.sum()
+      }
+    end
 
-  # Build a bunch of legs such that their start/end times follow each other
-  # (e.g. creating a coherent sequence)
-  defp build_leg_sequence(number) do
-    base_time = Timex.now("America/New_York")
+    def leg_time_factory do
+      %LegTime{
+        scheduled_time: Faker.DateTime.forward(2),
+        estimated: nil
+      }
+    end
 
-    transit_legs =
-      0..number
-      |> Enum.map(fn index ->
-        build(:transit_leg, %{
+    # Build a bunch of legs such that their start/end times follow each other
+    # (e.g. creating a coherent sequence)
+    defp build_leg_sequence(number) do
+      base_time = Timex.now("America/New_York")
+
+      transit_legs =
+        0..number
+        |> Enum.map(fn index ->
+          build(:transit_leg, %{
+            start:
+              sequence(:leg_start, fn _ ->
+                build(:leg_time, %{
+                  scheduled_time: Timex.shift(base_time, minutes: (index + 1) * 10)
+                })
+              end)
+          })
+        end)
+
+      %LegTime{scheduled_time: transit_start_time} = List.first(transit_legs).start
+      %LegTime{scheduled_time: transit_end_time} = List.last(transit_legs).end
+
+      first_walk_leg =
+        build(:walking_leg, %{
+          duration: random_seconds(),
+          end:
+            build(:leg_time, %{
+              scheduled_time: transit_start_time
+            }),
           start:
-            sequence(:leg_start, fn _ ->
-              build(:leg_time, %{
-                scheduled_time: Timex.shift(base_time, minutes: (index + 1) * 10)
-              })
-            end)
+            build(:leg_time, %{
+              scheduled_time: Timex.shift(transit_start_time, minutes: -random_seconds())
+            })
         })
-      end)
 
-    %LegTime{scheduled_time: transit_start_time} = List.first(transit_legs).start
-    %LegTime{scheduled_time: transit_end_time} = List.last(transit_legs).end
+      last_walk_leg =
+        build(:walking_leg, %{
+          start:
+            build(:leg_time, %{
+              scheduled_time: transit_end_time
+            })
+        })
 
-    first_walk_leg =
-      build(:walking_leg, %{
-        duration: random_seconds(),
-        end:
-          build(:leg_time, %{
-            scheduled_time: transit_start_time
+      [first_walk_leg | transit_legs ++ [last_walk_leg]]
+    end
+
+    def leg_factory(attrs) do
+      # coherence between timed values - end time should be after the start time,
+      # by the number of seconds specified in the duration.
+      duration = attrs[:duration] || random_seconds()
+      start_time = attrs[:start] || build(:leg_time)
+
+      end_time =
+        build(:leg_time, %{
+          scheduled_time: Timex.shift(start_time.scheduled_time, seconds: duration)
+        })
+
+      leg = %Leg{
+        agency: nil,
+        distance: random_distance(),
+        duration: duration,
+        end: end_time,
+        from: build(:place),
+        intermediate_stops: nil,
+        leg_geometry: build(:geometry),
+        mode: nil,
+        real_time: false,
+        realtime_state: nil,
+        route: nil,
+        start: start_time,
+        steps: nil,
+        transit_leg: nil,
+        trip: nil,
+        to: build(:place)
+      }
+
+      leg
+      |> merge_attributes(attrs)
+      |> evaluate_lazy_attributes()
+    end
+
+    def transit_leg_factory(attrs) do
+      agency = attrs[:agency] || build(:agency, %{name: "MBTA"})
+      trip_gtfs_id = gtfs_prefix(agency.name) <> Faker.Internet.slug()
+
+      build(:leg, %{
+        agency: agency,
+        from:
+          build(:place, %{
+            stop: build(:stop, %{gtfs_id: gtfs_prefix(agency.name) <> Faker.Internet.slug()})
           }),
-        start:
-          build(:leg_time, %{
-            scheduled_time: Timex.shift(transit_start_time, minutes: -random_seconds())
-          })
+        intermediate_stops:
+          build_list(3, :stop, %{
+            gtfs_id: fn ->
+              sequence(:intermediate_stop_id, fn _ ->
+                gtfs_prefix(agency.name) <> Faker.Internet.slug()
+              end)
+            end
+          }),
+        mode: "TRANSIT",
+        real_time: true,
+        realtime_state: Faker.Util.pick(Leg.realtime_state()),
+        route: attrs[:route] || build(:route),
+        to:
+          build(:place, %{
+            stop: build(:stop, %{gtfs_id: gtfs_prefix(agency.name) <> Faker.Internet.slug()})
+          }),
+        trip: build(:trip, %{gtfs_id: trip_gtfs_id}),
+        transit_leg: true
       })
+      |> merge_attributes(attrs)
+      |> evaluate_lazy_attributes()
+    end
 
-    last_walk_leg =
-      build(:walking_leg, %{
-        start:
-          build(:leg_time, %{
-            scheduled_time: transit_end_time
-          })
+    def walking_leg_factory do
+      build(:leg, %{
+        mode: "WALK",
+        steps: build_list(3, :step),
+        transit_leg: false
       })
+    end
 
-    [first_walk_leg | transit_legs ++ [last_walk_leg]]
+    def place_factory do
+      %Place{
+        name: Faker.Address.street_name(),
+        lat: Faker.Address.latitude(),
+        lon: Faker.Address.longitude(),
+        stop: nil
+      }
+    end
+
+    def route_factory do
+      %Route{
+        gtfs_id: gtfs_prefix() <> Faker.Internet.slug(),
+        short_name: Faker.Person.suffix(),
+        long_name: Faker.Color.fancy_name(),
+        type: Faker.Util.pick(Route.gtfs_route_type()),
+        color: Faker.Color.rgb_hex(),
+        text_color: Faker.Color.rgb_hex(),
+        desc: Faker.Company.catch_phrase()
+      }
+    end
+
+    def step_factory do
+      %Step{
+        absolute_direction: Faker.Util.pick(Step.absolute_direction()) |> Atom.to_string(),
+        distance: random_distance(),
+        relative_direction: Faker.Util.pick(Step.relative_direction()) |> Atom.to_string(),
+        street_name: Faker.Address.street_name()
+      }
+    end
+
+    def stop_factory do
+      %Stop{
+        gtfs_id: gtfs_prefix() <> Faker.Internet.slug(),
+        name: Faker.Address.city()
+      }
+    end
+
+    def trip_factory do
+      %Trip{
+        gtfs_id: gtfs_prefix() <> Faker.Internet.slug()
+      }
+    end
+
+    defp gtfs_prefix(agency_name \\ "MBTA")
+
+    defp gtfs_prefix(agency_name) when agency_name in ["Massport", "Logan Express"],
+      do: "massport-ma-us:"
+
+    defp gtfs_prefix(_), do: "mbta-ma-us:"
+
+    defp random_distance, do: Faker.random_uniform() * 2000
+    defp random_seconds, do: Faker.random_between(100, 1000)
   end
-
-  def leg_factory(attrs) do
-    # coherence between timed values - end time should be after the start time,
-    # by the number of seconds specified in the duration.
-    duration = attrs[:duration] || random_seconds()
-    start_time = attrs[:start] || build(:leg_time)
-
-    end_time =
-      build(:leg_time, %{
-        scheduled_time: Timex.shift(start_time.scheduled_time, seconds: duration)
-      })
-
-    leg = %Leg{
-      agency: nil,
-      distance: random_distance(),
-      duration: duration,
-      end: end_time,
-      from: build(:place),
-      intermediate_stops: nil,
-      leg_geometry: build(:geometry),
-      mode: nil,
-      real_time: false,
-      realtime_state: nil,
-      route: nil,
-      start: start_time,
-      steps: nil,
-      transit_leg: nil,
-      trip: nil,
-      to: build(:place)
-    }
-
-    leg
-    |> merge_attributes(attrs)
-    |> evaluate_lazy_attributes()
-  end
-
-  def transit_leg_factory(attrs) do
-    agency = attrs[:agency] || build(:agency, %{name: "MBTA"})
-    trip_gtfs_id = gtfs_prefix(agency.name) <> Faker.Internet.slug()
-
-    build(:leg, %{
-      agency: agency,
-      from:
-        build(:place, %{
-          stop: build(:stop, %{gtfs_id: gtfs_prefix(agency.name) <> Faker.Internet.slug()})
-        }),
-      intermediate_stops:
-        build_list(3, :stop, %{
-          gtfs_id: fn ->
-            sequence(:intermediate_stop_id, fn _ ->
-              gtfs_prefix(agency.name) <> Faker.Internet.slug()
-            end)
-          end
-        }),
-      mode: "TRANSIT",
-      real_time: true,
-      realtime_state: Faker.Util.pick(Leg.realtime_state()),
-      route: attrs[:route] || build(:route),
-      to:
-        build(:place, %{
-          stop: build(:stop, %{gtfs_id: gtfs_prefix(agency.name) <> Faker.Internet.slug()})
-        }),
-      trip: build(:trip, %{gtfs_id: trip_gtfs_id}),
-      transit_leg: true
-    })
-    |> merge_attributes(attrs)
-    |> evaluate_lazy_attributes()
-  end
-
-  def walking_leg_factory do
-    build(:leg, %{
-      mode: "WALK",
-      steps: build_list(3, :step),
-      transit_leg: false
-    })
-  end
-
-  def place_factory do
-    %Place{
-      name: Faker.Address.street_name(),
-      lat: Faker.Address.latitude(),
-      lon: Faker.Address.longitude(),
-      stop: nil
-    }
-  end
-
-  def route_factory do
-    %Route{
-      gtfs_id: gtfs_prefix() <> Faker.Internet.slug(),
-      short_name: Faker.Person.suffix(),
-      long_name: Faker.Color.fancy_name(),
-      type: Faker.Util.pick(Route.gtfs_route_type()),
-      color: Faker.Color.rgb_hex(),
-      text_color: Faker.Color.rgb_hex(),
-      desc: Faker.Company.catch_phrase()
-    }
-  end
-
-  def step_factory do
-    %Step{
-      absolute_direction: Faker.Util.pick(Step.absolute_direction()) |> Atom.to_string(),
-      distance: random_distance(),
-      relative_direction: Faker.Util.pick(Step.relative_direction()) |> Atom.to_string(),
-      street_name: Faker.Address.street_name()
-    }
-  end
-
-  def stop_factory do
-    %Stop{
-      gtfs_id: gtfs_prefix() <> Faker.Internet.slug(),
-      name: Faker.Address.city()
-    }
-  end
-
-  def trip_factory do
-    %Trip{
-      gtfs_id: gtfs_prefix() <> Faker.Internet.slug()
-    }
-  end
-
-  defp gtfs_prefix(agency_name \\ "MBTA")
-
-  defp gtfs_prefix(agency_name) when agency_name in ["Massport", "Logan Express"],
-    do: "massport-ma-us:"
-
-  defp gtfs_prefix(_), do: "mbta-ma-us:"
-
-  defp random_distance, do: Faker.random_uniform() * 2000
-  defp random_seconds, do: Faker.random_between(100, 1000)
 end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -1,4 +1,4 @@
-defmodule OpenTripPlannerClient.Test.Factory do
+defmodule OpenTripPlannerClient.Test.Support.Factory do
   @moduledoc """
   Generate OpenTripPlannerClient.Schema structs
   """


### PR DESCRIPTION
I didn't realize that `ex_machina` was being used in a factory in the `lib` directory. This PR moves it into `test/support` and then only compiles that directory in dev and test so that downstream libraries don't have to compile it for prod.